### PR TITLE
Creating files with utf8 encoding by default

### DIFF
--- a/src/AddAnyFilePackage.cs
+++ b/src/AddAnyFilePackage.cs
@@ -118,7 +118,7 @@ namespace MadsKristensen.AddAnyFile
 
         private static int WriteFile(string file)
         {
-            Encoding encoding = new UTF8Encoding(false);
+            Encoding encoding = new UTF8Encoding(true);
             string extension = Path.GetExtension(file);
 
             string assembly = Assembly.GetExecutingAssembly().Location;


### PR DESCRIPTION
Every time an utf8 character is saved in files created with this extension, Visual Studio shows the resave file dialog, which can easily become very annoying.

This feature was initially requested in [this issue](https://github.com/madskristensen/AddAnyFile/issues/10) and the amount of code it takes to fix it, is as minimal as it gets, but since nobody has responded to it since November, I took it upon myself to create this pull request.