### PR TITLE
Ensure complex root namespaces are not collapsed.

### DIFF
--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -34,15 +34,21 @@ namespace MadsKristensen.AddAnyFile
             }
             catch { /* Project doesn't have a root namespace */ }
 
-            return CleanNameSpace(ns);
+            return CleanNameSpace(ns, stripPeriods: false);
         }
 
-        public static string CleanNameSpace(string ns)
+        public static string CleanNameSpace(string ns, bool stripPeriods = true)
         {
-            return ns.Replace(" ", "")
-                     .Replace(".", "")
+            if (stripPeriods)
+            {
+                ns = ns.Replace(".", "");
+            }
+
+            ns = ns.Replace(" ", "")
                      .Replace("-", "")
                      .Replace("\\", ".");
+
+            return ns;
         }
 
         public static string GetRootFolder(this Project project)


### PR DESCRIPTION
This PR fixes an issue where complex root namespaces are incorrectly being collapsed.

For example, if your project has a default namespace of `Foo.Bar.Baz` and you create a file _Test\Testing.cs_, you will get an incorrect namespace of `FooBarBaz.Test`. With this PR, it will correctly resolve to `Foo.Bar.Baz.Test`.