### PR TITLE
Fix broken links to Visual Studio gallery

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -155,6 +155,6 @@ included in the project:
   `Place 'System' directives first when sorting usings` option is enabled (checked).
 - Before committing, organize usings for each updated C# source file. Either you can
   right-click editor and select `Organize Usings > Remove and sort` OR use extension
-  like [BatchFormat](http://visualstudiogallery.msdn.microsoft.com/a7f75c34-82b4-4357-9c66-c18e32b9393e).
+  like [BatchFormat](https://marketplace.visualstudio.com/items?itemName=vs-publisher-147549.BatchFormat).
 - Before committing, run Code Analysis in `Debug` configuration and follow the guidelines
   to fix CA issues. Code Analysis commits can be made separately.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/252jpryc38qah37x?svg=true)](https://ci.appveyor.com/project/madskristensen/addanyfile)
 
 Download the extension at the
-[VS Gallery](http://visualstudiogallery.msdn.microsoft.com/3f820e99-6c0d-41db-aa74-a18d9623b1f3)
+[VS Gallery](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.AddNewFile)
 or get the
 [nightly build](http://vsixgallery.com/extension/2E78AA18-E864-4FBB-B8C8-6186FC865DB3/)
 
@@ -46,7 +46,7 @@ if you want to contribute to this project.
 
 For cloning and building this project yourself, make sure
 to install the
-[Extensibility Tools 2015](https://visualstudiogallery.msdn.microsoft.com/ab39a092-1343-46e2-b0f1-6a3f91155aa6)
+[Extensibility Tools 2015](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityTools)
 extension for Visual Studio which enables some features
 used by this project.
 

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
         <Identity Id="2E78AA18-E864-4FBB-B8C8-6186FC865DB3" Version="3.5" Language="en-US" Publisher="Mads Kristensen" />
         <DisplayName>Add New File</DisplayName>
         <Description xml:space="preserve">The fastest and easiest way to add new files to any project - including files that start with a dot</Description>
-        <MoreInfo>https://visualstudiogallery.msdn.microsoft.com/3f820e99-6c0d-41db-aa74-a18d9623b1f3</MoreInfo>
+        <MoreInfo>https://marketplace.visualstudio.com/items?itemName=MadsKristensen.AddNewFile</MoreInfo>
         <License>Resources\LICENSE</License>
         <ReleaseNotes>https://github.com/madskristensen/AddAnyFile/blob/master/CHANGELOG.md</ReleaseNotes>
         <Icon>Resources\logo.png</Icon>


### PR DESCRIPTION
The old links to https://visualstudiogallery.msdn.microsoft.com no
longer work. The SSL certificate expired on 2020/03/20 and the site does
not allow insecure connections.