### PR TITLE
Support solution folders and solution items

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,84 @@
+[*.vsct]
+
+indent_style = space
+indent_size = 4
+charset = utf-8-bom
+
+[*.cs]
+
+#Core editorconfig formatting - indentation
+
+indent_style = tab
+charset = utf-8-bom
+
+#Formatting - new line options
+
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = methods, control_blocks, object_collection_array_initializers, types
+
+#Formatting - organize using options
+
+dotnet_sort_system_directives_first = false
+
+#Formatting - spacing options
+
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+csharp_preserve_single_line_blocks = true
+
+#Style - Code block preferences
+
+csharp_prefer_braces = true:suggestion
+
+#Style - expression bodied member options
+
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+
+#Style - expression level options
+
+csharp_style_inlined_variable_declaration = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+dotnet_style_object_initializer = true:suggestion
+
+#Style - implicit and explicit types
+
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+
+#Style - language keyword and framework type options
+
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - modifier options
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+csharp_preferred_modifier_order = private,public,internal,protected,static,async,readonly,override:suggestion
+
+#Style - Pattern matching
+
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+#Style - qualification options
+
+dotnet_style_qualification_for_method = false:suggestion

--- a/AddAnyFile.sln
+++ b/AddAnyFile.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AddAnyFile", "src\AddAnyFil
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{50C409A6-1C74-4C72-887A-3AC964BD505D}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
 		CHANGELOG.md = CHANGELOG.md
 		README.md = README.md

--- a/src/AddAnyFile.csproj
+++ b/src/AddAnyFile.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Helpers\Logger.cs" />
     <Compile Include="Helpers\ProjectHelpers.cs" />
     <Compile Include="Helpers\VsTheme.cs" />
+    <Compile Include="NewItemTarget.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>

--- a/src/AddAnyFile.vsct
+++ b/src/AddAnyFile.vsct
@@ -17,6 +17,16 @@
         </Buttons>
     </Commands>
 
+    <CommandPlacements>
+        <CommandPlacement guid="guidAddAnyFileCmdSet" id="cmdidMyCommand" priority="0x0200">
+            <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_ADD_ITEM"/>
+        </CommandPlacement>
+
+        <CommandPlacement guid="guidAddAnyFileCmdSet" id="cmdidMyCommand" priority="0x0200">
+            <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SLNFLDR_ADD_ITEM"/>
+        </CommandPlacement>
+    </CommandPlacements>
+
     <KeyBindings>
         <KeyBinding guid="guidAddAnyFileCmdSet" id="cmdidMyCommand" mod1="Shift" key1="VK_F2" editor="guidVSStd97"/>
     </KeyBindings>

--- a/src/AddAnyFilePackage.cs
+++ b/src/AddAnyFilePackage.cs
@@ -27,6 +27,8 @@ namespace MadsKristensen.AddAnyFile
 	[Guid(PackageGuids.guidAddAnyFilePkgString)]
 	public sealed class AddAnyFilePackage : AsyncPackage
 	{
+		private const string SolutionItemsProjectName = "Solution Items";
+
 		public static DTE2 _dte;
 
 		protected override async System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
@@ -48,24 +50,19 @@ namespace MadsKristensen.AddAnyFile
 
 		private async void ExecuteAsync(object sender, EventArgs e)
 		{
-			object item = ProjectHelpers.GetSelectedItem();
-			string folder = FindFolder(item);
+			NewItemTarget target = NewItemTarget.Create(_dte);
 
-			if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+			if (target == null)
 			{
+				MessageBox.Show(
+						"Could not determine where to create the new file. Select a file or folder in Solution Explorer and try again.",
+						Vsix.Name,
+						MessageBoxButton.OK,
+						MessageBoxImage.Error);
 				return;
 			}
 
-			ProjectItem selectedItem = item as ProjectItem;
-			Project selectedProject = item as Project;
-			Project project = selectedItem?.ContainingProject ?? selectedProject ?? ProjectHelpers.GetActiveProject();
-
-			if (project == null)
-			{
-				return;
-			}
-
-			string input = PromptForFileName(folder).TrimStart('/', '\\').Replace("/", "\\");
+			string input = PromptForFileName(target.Directory).TrimStart('/', '\\').Replace("/", "\\");
 
 			if (string.IsNullOrEmpty(input))
 			{
@@ -74,93 +71,122 @@ namespace MadsKristensen.AddAnyFile
 
 			string[] parsedInputs = GetParsedInput(input);
 
-			foreach (string inputItem in parsedInputs)
+			foreach (string name in parsedInputs)
 			{
-				input = inputItem;
-
-				if (input.EndsWith("\\", StringComparison.Ordinal))
-				{
-					input = input + "__dummy__";
-				}
-
-				FileInfo file = null;
-
 				try
 				{
-					file = new FileInfo(Path.Combine(folder, input));
+					await AddItemAsync(name, target);
 				}
 				catch (PathTooLongException ex)
 				{
 					MessageBox.Show("The file name is too long 😢", Vsix.Name, MessageBoxButton.OK, MessageBoxImage.Error);
 					Logger.Log(ex);
-					continue;
 				}
 				catch (Exception ex)
 				{
 					Logger.Log(ex);
-					continue;
+					MessageBox.Show(
+							$"Error creating file '{name}':{Environment.NewLine}{ex.Message}",
+							Vsix.Name,
+							MessageBoxButton.OK,
+							MessageBoxImage.Error);
 				}
+			}
+		}
 
-				if (!IsFileNameValid(file.Name))
+		private async System.Threading.Tasks.Task AddItemAsync(string name, NewItemTarget target)
+		{
+			if (name.EndsWith("\\", StringComparison.Ordinal))
+			{
+				if (target.IsSolutionOrSolutionFolder)
 				{
-					MessageBox.Show($"The file name '{file.Name}' is a system reserved name.", Vsix.Name, MessageBoxButton.OK, MessageBoxImage.Error);
-					continue;
-				}
-
-				string dir = file.DirectoryName;
-
-				PackageUtilities.EnsureOutputPath(dir);
-
-				if (!file.Exists)
-				{
-					try
-					{
-						int position = await WriteFileAsync(project, file.FullName);
-						ProjectItem projectItem = null;
-
-						if (item is ProjectItem projItem)
-						{
-							if ("{6BB5F8F0-4483-11D3-8BCF-00C04F8EC28C}" == projItem.Kind) // Constants.vsProjectItemKindVirtualFolder
-							{
-								projectItem = projItem.ProjectItems.AddFromFile(file.FullName);
-							}
-						}
-						if (projectItem == null)
-						{
-							projectItem = project.AddFileToProject(file);
-						}
-
-						if (file.FullName.EndsWith("__dummy__"))
-						{
-							projectItem?.Delete();
-							continue;
-						}
-
-						VsShellUtilities.OpenDocument(this, file.FullName);
-
-						// Move cursor into position
-						if (position > 0)
-						{
-							Microsoft.VisualStudio.Text.Editor.IWpfTextView view = ProjectHelpers.GetCurentTextView();
-
-							if (view != null)
-							{
-								view.Caret.MoveTo(new SnapshotPoint(view.TextBuffer.CurrentSnapshot, position));
-							}
-						}
-
-						_dte.ExecuteCommand("SolutionExplorer.SyncWithActiveDocument");
-						_dte.ActiveDocument.Activate();
-					}
-					catch (Exception ex)
-					{
-						Logger.Log(ex);
-					}
+					GetOrAddSolutionFolder(name, target);
 				}
 				else
 				{
-					System.Windows.Forms.MessageBox.Show("The file '" + file + "' already exist.");
+					AddProjectFolder(name, target);
 				}
+			}
+			else
+			{
+				await AddFileAsync(name, target);
+			}
+		}
+
+		private async System.Threading.Tasks.Task AddFileAsync(string name, NewItemTarget target)
+		{
+			FileInfo file;
+
+
+			// If the file is being added to a solution folder, but that
+			// solution folder doesn't have a corresponding directory on
+			// disk, then write the file to the root of the solution instead.
+			if (target.IsSolutionFolder && !Directory.Exists(target.Directory))
+			{
+				file = new FileInfo(Path.Combine(Path.GetDirectoryName(_dte.Solution.FullName), Path.GetFileName(name)));
+			}
+			else
+			{
+				file = new FileInfo(Path.Combine(target.Directory, name));
+			}
+
+			if (!IsFileNameValid(file.Name))
+			{
+				MessageBox.Show($"The file name '{file.Name}' is a system reserved name.", Vsix.Name, MessageBoxButton.OK, MessageBoxImage.Error);
+				return;
+			}
+
+			PackageUtilities.EnsureOutputPath(file.DirectoryName);
+
+			if (!file.Exists)
+			{
+				try
+				{
+					Project project;
+
+					if (target.IsSolutionOrSolutionFolder)
+					{
+						project = GetOrAddSolutionFolder(Path.GetDirectoryName(name), target);
+					}
+					else
+					{
+						project = target.Project;
+					}
+
+					int position = await WriteFileAsync(project, file.FullName);
+					if (target.ProjectItem != null && target.ProjectItem.IsKind(Constants.vsProjectItemKindVirtualFolder))
+					{
+						target.ProjectItem.ProjectItems.AddFromFile(file.FullName);
+					}
+					else
+					{
+						project.AddFileToProject(file);
+					}
+
+					VsShellUtilities.OpenDocument(this, file.FullName);
+
+					// Move cursor into position.
+					if (position > 0)
+					{
+						Microsoft.VisualStudio.Text.Editor.IWpfTextView view = ProjectHelpers.GetCurentTextView();
+
+						if (view != null)
+						{
+							view.Caret.MoveTo(new SnapshotPoint(view.TextBuffer.CurrentSnapshot, position));
+						}
+					}
+
+					_dte.ExecuteCommand("SolutionExplorer.SyncWithActiveDocument");
+					_dte.ActiveDocument.Activate();
+				}
+				catch (Exception ex)
+				{
+					Logger.Log(ex);
+				}
+			}
+			else
+			{
+				MessageBox.Show($"The file '{file}' already exists.", Vsix.Name, MessageBoxButton.OK, MessageBoxImage.Information);
 			}
 		}
 
@@ -214,6 +240,81 @@ namespace MadsKristensen.AddAnyFile
 			return new UTF8Encoding(true);
 		}
 
+		private Project GetOrAddSolutionFolder(string name, NewItemTarget target)
+		{
+			if (target.IsSolution && string.IsNullOrEmpty(name))
+			{
+				// An empty solution folder name means we are not creating any solution 
+				// folders for that item, and the file we are adding is intended to be 
+				// added to the solution. Files cannot be added directly to the solution,
+				// so there is a "Solution Items" folder that they are added to.
+				return _dte.Solution.FindSolutionFolder(SolutionItemsProjectName)
+						?? ((Solution2)_dte.Solution).AddSolutionFolder(SolutionItemsProjectName);
+			}
+
+			// Even though solution folders are always virtual, if the target directory exists,
+			// then we will also create the new directory on disk. This ensures that any files
+			// that are added to this folder will end up in the corresponding physical directory.
+			if (Directory.Exists(target.Directory))
+			{
+				PackageUtilities.EnsureOutputPath(Path.Combine(target.Directory, name));
+			}
+
+			Project parent = target.Project;
+
+			foreach (string segment in SplitPath(name))
+			{
+				// If we don't have a parent project yet, 
+				// then this folder is added to the solution.
+				if (parent == null)
+				{
+					parent = _dte.Solution.FindSolutionFolder(segment) ?? ((Solution2)_dte.Solution).AddSolutionFolder(segment);
+				}
+				else
+				{
+					parent = parent.FindSolutionFolder(segment) ?? ((SolutionFolder)parent.Object).AddSolutionFolder(segment);
+				}
+			}
+
+			return parent;
+		}
+
+		private void AddProjectFolder(string name, NewItemTarget target)
+		{
+			// Make sure the directory exists before we add it to the project.
+			PackageUtilities.EnsureOutputPath(Path.Combine(target.Directory, name));
+
+			// We can't just add the final directory to the project because that will 
+			// only add the final segment rather than adding each segment in the path.
+			// Split the name into segments and add each folder individually.
+			ProjectItems items = target.ProjectItem?.ProjectItems ?? target.Project.ProjectItems;
+			string parentDirectory = target.Directory;
+
+			foreach (string segment in SplitPath(name))
+			{
+				parentDirectory = Path.Combine(parentDirectory, segment);
+
+				// Look for an existing folder in case it's already in the project.
+				ProjectItem folder = items
+						.OfType<ProjectItem>()
+						.Where(item => segment.Equals(item.Name, StringComparison.OrdinalIgnoreCase))
+						.Where(item => item.IsKind(Constants.vsProjectItemKindPhysicalFolder, Constants.vsProjectItemKindVirtualFolder))
+						.FirstOrDefault();
+
+				if (folder == null)
+				{
+					folder = items.AddFromDirectory(parentDirectory);
+				}
+
+				items = folder.ProjectItems;
+			}
+		}
+
+		private static string[] SplitPath(string path)
+		{
+			return path.Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries);
+		}
+
 		private static string[] GetParsedInput(string input)
 		{
 			// var tests = new string[] { "file1.txt", "file1.txt, file2.txt", ".ignore", ".ignore.(old,new)", "license", "folder/",
@@ -255,73 +356,6 @@ namespace MadsKristensen.AddAnyFile
 
 			bool? result = dialog.ShowDialog();
 			return (result.HasValue && result.Value) ? dialog.Input : string.Empty;
-		}
-
-		private static string FindFolder(object item)
-		{
-			if (item == null)
-			{
-				return null;
-			}
-
-			if (_dte.ActiveWindow is Window2 window && window.Type == vsWindowType.vsWindowTypeDocument)
-			{
-				// if a document is active, use the document's containing directory
-				Document doc = _dte.ActiveDocument;
-				if (doc != null && !string.IsNullOrEmpty(doc.FullName))
-				{
-					ProjectItem docItem = _dte.Solution.FindProjectItem(doc.FullName);
-
-					if (docItem != null && docItem.Properties != null)
-					{
-						string fileName = docItem.Properties.Item("FullPath").Value.ToString();
-						if (File.Exists(fileName))
-						{
-							return Path.GetDirectoryName(fileName);
-						}
-					}
-				}
-			}
-
-			string folder = null;
-
-			ProjectItem projectItem = item as ProjectItem;
-			if (projectItem != null && "{6BB5F8F0-4483-11D3-8BCF-00C04F8EC28C}" == projectItem.Kind) //Constants.vsProjectItemKindVirtualFolder
-			{
-				ProjectItems items = projectItem.ProjectItems;
-				foreach (ProjectItem it in items)
-				{
-					if (File.Exists(it.FileNames[1]))
-					{
-						folder = Path.GetDirectoryName(it.FileNames[1]);
-						break;
-					}
-				}
-			}
-			else
-			{
-				Project project = item as Project;
-				if (projectItem != null)
-				{
-					string fileName = projectItem.FileNames[1];
-
-					if (File.Exists(fileName))
-					{
-						folder = Path.GetDirectoryName(fileName);
-					}
-					else
-					{
-						folder = fileName;
-					}
-
-
-				}
-				else if (project != null)
-				{
-					folder = project.GetRootFolder();
-				}
-			}
-			return folder;
 		}
 	}
 }

--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -171,6 +171,23 @@ namespace MadsKristensen.AddAnyFile
 			}
 		}
 
+		public static Project FindSolutionFolder(this Solution solution, string name)
+		{
+			return solution.Projects.OfType<Project>()
+					.Where(p => p.IsKind(EnvDTE.Constants.vsProjectKindSolutionItems))
+					.Where(p => p.Name == name)
+					.FirstOrDefault();
+		}
+
+		public static Project FindSolutionFolder(this Project project, string name)
+		{
+			return project.ProjectItems.OfType<ProjectItem>()
+					.Where(p => p.IsKind(EnvDTE.Constants.vsProjectItemKindSolutionItems))
+					.Where(p => p.Name == name)
+					.Select(p => p.SubProject)
+					.FirstOrDefault();
+		}
+
 		public static bool IsKind(this Project project, params string[] kindGuids)
 		{
 			foreach (string guid in kindGuids)

--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -171,6 +171,19 @@ namespace MadsKristensen.AddAnyFile
 			return false;
 		}
 
+		public static bool IsKind(this ProjectItem projectItem, params string[] kindGuids)
+		{
+			foreach (string guid in kindGuids)
+			{
+				if (projectItem.Kind.Equals(guid, StringComparison.OrdinalIgnoreCase))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		private static IEnumerable<Project> GetChildProjects(Project parent)
 		{
 			try

--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -158,6 +158,19 @@ namespace MadsKristensen.AddAnyFile
 			}
 		}
 
+		public static string GetFileName(this ProjectItem item)
+		{
+			try
+			{
+				return item?.Properties?.Item("FullPath").Value?.ToString();
+			}
+			catch (ArgumentException)
+			{
+				// The property does not exist.
+				return null;
+			}
+		}
+
 		public static bool IsKind(this Project project, params string[] kindGuids)
 		{
 			foreach (string guid in kindGuids)

--- a/src/NewItemTarget.cs
+++ b/src/NewItemTarget.cs
@@ -1,0 +1,164 @@
+﻿using EnvDTE;
+using EnvDTE80;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace MadsKristensen.AddAnyFile
+{
+	public class NewItemTarget
+	{
+		public static NewItemTarget Create(DTE2 dte)
+		{
+			NewItemTarget item = null;
+
+			// If a document is active, try to use the document's containing directory.
+			if (dte.ActiveWindow is Window2 window && window.Type == vsWindowType.vsWindowTypeDocument)
+			{
+				item = CreateFromActiveDocument(dte);
+			}
+
+			// If no document was selected, or we could not get a selected item from 
+			// the document, then use the selected item in the Solution Explorer window.
+			if (item == null)
+			{
+				item = CreateFromSolutionExplorerSelection(dte);
+			}
+
+			return item;
+		}
+
+		private static NewItemTarget CreateFromActiveDocument(DTE2 dte)
+		{
+			string fileName = dte.ActiveDocument?.FullName;
+			if (File.Exists(fileName))
+			{
+				ProjectItem docItem = dte.Solution.FindProjectItem(fileName);
+				if (docItem != null)
+				{
+					return CreateFromProjectItem(docItem);
+				}
+			}
+
+			return null;
+		}
+
+		private static NewItemTarget CreateFromSolutionExplorerSelection(DTE2 dte)
+		{
+			Array items = (Array)dte.ToolWindows.SolutionExplorer.SelectedItems;
+
+			if (items.Length == 1)
+			{
+				UIHierarchyItem selection = items.Cast<UIHierarchyItem>().First();
+
+				if (selection.Object is Solution solution)
+				{
+					return new NewItemTarget(Path.GetDirectoryName(solution.FullName), null, null, isSolutionOrSolutionFolder: true);
+				}
+				else if (selection.Object is Project project)
+				{
+					if (project.IsKind(Constants.vsProjectKindSolutionItems))
+					{
+						return new NewItemTarget(GetSolutionFolderPath(project), project, null, isSolutionOrSolutionFolder: true);
+					}
+					else
+					{
+						return new NewItemTarget(project.GetRootFolder(), project, null, isSolutionOrSolutionFolder: false);
+					}
+				}
+				else if (selection.Object is ProjectItem projectItem)
+				{
+					return CreateFromProjectItem(projectItem);
+				}
+			}
+
+			return null;
+		}
+
+		private static NewItemTarget CreateFromProjectItem(ProjectItem projectItem)
+		{
+			if (projectItem.IsKind(Constants.vsProjectItemKindSolutionItems))
+			{
+				return new NewItemTarget(
+						GetSolutionFolderPath(projectItem.ContainingProject),
+						projectItem.ContainingProject,
+						null,
+						isSolutionOrSolutionFolder: true);
+			}
+			else
+			{
+				// The selected item needs a directory. This project item could be 
+				// a virtual folder, so resolve it to a physical file or folder.
+				projectItem = ResolveToPhysicalProjectItem(projectItem);
+				string fileName = projectItem?.GetFileName();
+
+				if (string.IsNullOrEmpty(fileName))
+				{
+					return null;
+				}
+
+				// If the file exists, then it must be a file and we can get the
+				// directory name from it. If the file does not exist, then it
+				// must be a directory, and the directory name is the file name.
+				string directory = File.Exists(fileName) ? Path.GetDirectoryName(fileName) : fileName;
+				return new NewItemTarget(directory, projectItem.ContainingProject, projectItem, isSolutionOrSolutionFolder: false);
+			}
+		}
+
+		private static ProjectItem ResolveToPhysicalProjectItem(ProjectItem projectItem)
+		{
+			if (projectItem.IsKind(Constants.vsProjectItemKindVirtualFolder))
+			{
+				// Find the first descendant item that is not a virtual folder.
+				return projectItem.ProjectItems
+						.Cast<ProjectItem>()
+						.Select(item => ResolveToPhysicalProjectItem(item))
+						.FirstOrDefault(item => item != null);
+			}
+
+			return projectItem;
+		}
+
+		private static string GetSolutionFolderPath(Project folder)
+		{
+			string solutionDirectory = Path.GetDirectoryName(folder.DTE.Solution.FullName);
+			List<string> segments = new List<string>();
+
+			// Record the names of each folder up the 
+			// hierarchy until we reach the solution.
+			do
+			{
+				segments.Add(folder.Name);
+				folder = folder.ParentProjectItem?.ContainingProject;
+			} while (folder != null);
+
+			// Because we walked up the hierarchy, 
+			// the path segments are in reverse order.
+			segments.Reverse();
+
+			return Path.Combine(new[] { solutionDirectory }.Concat(segments).ToArray());
+		}
+
+		private NewItemTarget(string directory, Project project, ProjectItem projectItem, bool isSolutionOrSolutionFolder)
+		{
+			Directory = directory;
+			Project = project;
+			ProjectItem = projectItem;
+			IsSolutionOrSolutionFolder = isSolutionOrSolutionFolder;
+		}
+
+		public string Directory { get; }
+
+		public Project Project { get; }
+
+		public ProjectItem ProjectItem { get; }
+
+		public bool IsSolutionOrSolutionFolder { get; }
+
+		public bool IsSolution => IsSolutionOrSolutionFolder && Project == null;
+
+		public bool IsSolutionFolder => IsSolutionOrSolutionFolder && Project != null;
+
+	}
+}


### PR DESCRIPTION
Fixes #74.

These changes ended up being larger than I would have liked, but I felt they were necessary for two reasons: 
1. `IVsMonitorSelection.GetCurrentSelection()` didn't appear to be return anything when the solution was selected.
2. Trying to add the creation of solution folders into the existing code path was too complicated. Splitting the code into separate paths for solution folders, project folders and files was much easier.

# Target Directory Logic

Solution folders are virtual, so adding a solution folder doesn't create a directory on disk. Likewise, adding a file to the solution doesn't require that file to be at the root of the solution. However, I thought it would make more sense that if the solution folder has a corresponding directory on disk, then the file should be created in that directory. If the folder doesn't exist on disk, then the file can be created at the root of the solution. This is the logic that I have implemented:

| Selection | Folder exists on disk | New file name | Created on disk at           | Added to solution at               |
|-----------|:---------------------:|---------------|------------------------------|------------------------------------|
| Solution  | ✔️                    | file.txt      | \<solution root>/file.txt     | \<solution>/Solution Items/file.txt |
| Solution  | ✔️                    | foo/file.txt  | \<solution root>/foo/file.txt | \<solution>/foo/file.txt            |
| Solution  | ✔️                    | foo/          | \<solution root>/foo/         | \<solution>/foo/                    |
| Folder    | ✔️                    | file.txt      | \<folder>/file.txt            | \<folder>/file.txt                  |
| Folder    | ❌                     | file.txt      | \<solution root>/file.txt     | \<folder>/file.txt                  |
| Folder    | ✔️                    | foo/file.txt  | \<folder>/foo/file.txt        | \<folder>/foo/file.txt              |
| Folder    | ❌                     | foo/file.txt  | \<solution root>/file.txt     | \<folder>/foo/file.txt              |
| Folder    | ✔️                    | foo/          | \<folder>/foo/                | \<folder>/foo/                      |
| Folder    | ❌                     | foo/          | \<solution root>/foo/         | \<folder>/foo/                      |

# Selected Item Logic

I've changed how the selected item is determined, which controls where the new file/folder is created. With the existing logic, the selected item in Solution Explorer would be used to determine which project to add the new file to, but the active document _could_ have been used to determine where the file should be written to disk. If the active document and Solution Explorer weren't in sync, that could result in a file being written to disk outside of the project that it was added to.

Adding solution folders into the mix means you could end up creating a file at the path of the solution folder, but added it to a project.

I changed the logic to use either one or the other. Either it uses the project and directory of the active document, or it uses the project and directory of the selected item in Solution Explorer. All of that logic is in the `NewItemTarget.Create()` method.

# Adding Project Folders

I've also changed how folders are added to projects. Instead of writing a dummy file to disk, adding the file to the project, then deleting the file, the folder is added to the project via `ProjectItems.AddFromDirectory()`.

## editorconfig

I've added an editoconfig file so that the code style doesn't have to be configured manually in Visual Studio. It was mostly generated by Intellicode. I only had to add the section for `vsct` files.
