### PR TITLE
Improve error handler for invalid paths

### DIFF
--- a/src/AddAnyFilePackage.cs
+++ b/src/AddAnyFilePackage.cs
@@ -1,8 +1,9 @@
-using EnvDTE;
+﻿using EnvDTE;
 
 using EnvDTE80;
 
 using Microsoft;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 
@@ -79,12 +80,7 @@ namespace MadsKristensen.AddAnyFile
 				{
 					await AddItemAsync(name, target);
 				}
-				catch (PathTooLongException ex)
-				{
-					MessageBox.Show("The file name is too long 😢", Vsix.Name, MessageBoxButton.OK, MessageBoxImage.Error);
-					Logger.Log(ex);
-				}
-				catch (Exception ex)
+				catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
 				{
 					Logger.Log(ex);
 					MessageBox.Show(

--- a/src/AddAnyFilePackage.cs
+++ b/src/AddAnyFilePackage.cs
@@ -136,7 +136,9 @@ namespace MadsKristensen.AddAnyFile
 				return;
 			}
 
-			PackageUtilities.EnsureOutputPath(file.DirectoryName);
+			// Make sure the directory exists before we create the file. Don't use
+			// `PackageUtilities.EnsureOutputPath()` because it can silently fail.
+			Directory.CreateDirectory(file.DirectoryName);
 
 			if (!file.Exists)
 			{
@@ -250,7 +252,8 @@ namespace MadsKristensen.AddAnyFile
 			// that are added to this folder will end up in the corresponding physical directory.
 			if (Directory.Exists(target.Directory))
 			{
-				PackageUtilities.EnsureOutputPath(Path.Combine(target.Directory, name));
+				// Don't use `PackageUtilities.EnsureOutputPath()` because it can silently fail.
+				Directory.CreateDirectory(Path.Combine(target.Directory, name));
 			}
 
 			Project parent = target.Project;
@@ -274,8 +277,9 @@ namespace MadsKristensen.AddAnyFile
 
 		private void AddProjectFolder(string name, NewItemTarget target)
 		{
-			// Make sure the directory exists before we add it to the project.
-			PackageUtilities.EnsureOutputPath(Path.Combine(target.Directory, name));
+			// Make sure the directory exists before we add it to the project. Don't
+			// use `PackageUtilities.EnsureOutputPath()` because it can silently fail.
+			Directory.CreateDirectory(Path.Combine(target.Directory, name));
 
 			// We can't just add the final directory to the project because that will 
 			// only add the final segment rather than adding each segment in the path.

--- a/src/AddAnyFilePackage.cs
+++ b/src/AddAnyFilePackage.cs
@@ -1,4 +1,4 @@
-﻿using EnvDTE;
+using EnvDTE;
 
 using EnvDTE80;
 
@@ -140,49 +140,42 @@ namespace MadsKristensen.AddAnyFile
 
 			if (!file.Exists)
 			{
-				try
+				Project project;
+
+				if (target.IsSolutionOrSolutionFolder)
 				{
-					Project project;
-
-					if (target.IsSolutionOrSolutionFolder)
-					{
-						project = GetOrAddSolutionFolder(Path.GetDirectoryName(name), target);
-					}
-					else
-					{
-						project = target.Project;
-					}
-
-					int position = await WriteFileAsync(project, file.FullName);
-					if (target.ProjectItem != null && target.ProjectItem.IsKind(Constants.vsProjectItemKindVirtualFolder))
-					{
-						target.ProjectItem.ProjectItems.AddFromFile(file.FullName);
-					}
-					else
-					{
-						project.AddFileToProject(file);
-					}
-
-					VsShellUtilities.OpenDocument(this, file.FullName);
-
-					// Move cursor into position.
-					if (position > 0)
-					{
-						Microsoft.VisualStudio.Text.Editor.IWpfTextView view = ProjectHelpers.GetCurentTextView();
-
-						if (view != null)
-						{
-							view.Caret.MoveTo(new SnapshotPoint(view.TextBuffer.CurrentSnapshot, position));
-						}
-					}
-
-					ExecuteCommandIfAvailable("SolutionExplorer.SyncWithActiveDocument");
-					_dte.ActiveDocument.Activate();
+					project = GetOrAddSolutionFolder(Path.GetDirectoryName(name), target);
 				}
-				catch (Exception ex)
+				else
 				{
-					Logger.Log(ex);
+					project = target.Project;
 				}
+
+				int position = await WriteFileAsync(project, file.FullName);
+				if (target.ProjectItem != null && target.ProjectItem.IsKind(Constants.vsProjectItemKindVirtualFolder))
+				{
+					target.ProjectItem.ProjectItems.AddFromFile(file.FullName);
+				}
+				else
+				{
+					project.AddFileToProject(file);
+				}
+
+				VsShellUtilities.OpenDocument(this, file.FullName);
+
+				// Move cursor into position.
+				if (position > 0)
+				{
+					Microsoft.VisualStudio.Text.Editor.IWpfTextView view = ProjectHelpers.GetCurentTextView();
+
+					if (view != null)
+					{
+						view.Caret.MoveTo(new SnapshotPoint(view.TextBuffer.CurrentSnapshot, position));
+					}
+				}
+
+				ExecuteCommandIfAvailable("SolutionExplorer.SyncWithActiveDocument");
+				_dte.ActiveDocument.Activate();
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #83 and #76.

This PR contains a few changes that, together, fix #83 and improve the error handling when creating a file that contains a reserved file name, or invalid characters (such as `?` or `:`).

1. I've removed the try/catch block that was only logging an error but not alerting the user. Any errors will now flow up to the catch statement in the command's `ExecuteAsync` method.
2. `PackageUtilities.EnsureOutputPath` can fail silently. If certain error (such as an `IOException`) occur when creating the path, it just catches them and traces a message. I've changed these calls to `Directory.CreateDirectory()` so that an exception will be thrown if the directory cannot be created. The exception will be caught in the command's `ExecuteAsync` method.
3. Checking for reserved file names (`COM1`, `LPT1`, etc) now occurs for files _and_ directories. Previously it only occurred for files. This validation also includes checking the paths for invalid characters like `?` and `:`.
4. I've removed the specific catch clause for a `PathNotFoundException`. The exception will now be handled by the general catch clause, and the error message is a bit more descriptive:
![image](https://user-images.githubusercontent.com/10321525/112133857-d922b900-8c17-11eb-8d88-b8d2f6b757fa.png)
