### PR TITLE
Attempt to fix #90 by registering adding the item as from a template.

### DIFF
--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -130,7 +130,10 @@ namespace MadsKristensen.AddAnyFile
 				return null;
 			}
 
-			ProjectItem item = project.ProjectItems.AddFromTemplate(file.FullName, file.FullName);
+			// Appears to be a bug in project system or VS, so need to make sure the project is aware of the folder structure first,
+			// then add the time to that folderStructure (create and/or find)
+			ProjectItem folderItem = project.ProjectItems.AddFolder(file.DirectoryName);
+			ProjectItem item = folderItem.ProjectItems.AddFromTemplate(file.FullName, file.Name);
 			item.SetItemType(itemType);
 			return item;
 		}

--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -117,6 +117,7 @@ namespace MadsKristensen.AddAnyFile
 
 		public static ProjectItem AddFileToProject(this Project project, FileInfo file, string itemType = null)
 		{
+			ThreadHelper.ThrowIfNotOnUIThread();
 			if (project.IsKind(ProjectTypes.ASPNET_5, ProjectTypes.SSDT))
 			{
 				return _dte.Solution.FindProjectItem(file.FullName);
@@ -129,8 +130,7 @@ namespace MadsKristensen.AddAnyFile
 				return null;
 			}
 
-			//ProjectItem item = project.ProjectItems.AddFromFile(file.FullName);
-			ProjectItem item = project.ProjectItems.AddFromTemplate(file.FullName, itemType);
+			ProjectItem item = project.ProjectItems.AddFromTemplate(file.FullName, file.FullName);
 			item.SetItemType(itemType);
 			return item;
 		}

--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -132,9 +133,21 @@ namespace MadsKristensen.AddAnyFile
 
 			// Appears to be a bug in project system or VS, so need to make sure the project is aware of the folder structure first,
 			// then add the time to that folderStructure (create and/or find)
-			ProjectItem folderItem = project.ProjectItems.AddFolder(file.DirectoryName);
-			ProjectItem item = folderItem.ProjectItems.AddFromTemplate(file.FullName, file.Name);
+			// if adding to the root ProjectItem then just do that.
+			ProjectItems projectItems;
+			if (string.Equals(root.TrimEnd(Path.DirectorySeparatorChar), file.DirectoryName, StringComparison.InvariantCultureIgnoreCase))
+			{
+				projectItems = project.ProjectItems;
+			}
+			else
+			{
+				ProjectItem folderItem = project.ProjectItems.AddFolder(file.DirectoryName);
+				projectItems = folderItem.ProjectItems;
+			}
+			
+			ProjectItem item = projectItems.AddFromTemplate(file.FullName, file.Name);
 			item.SetItemType(itemType);
+			
 			return item;
 		}
 

--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -129,7 +129,8 @@ namespace MadsKristensen.AddAnyFile
 				return null;
 			}
 
-			ProjectItem item = project.ProjectItems.AddFromFile(file.FullName);
+			//ProjectItem item = project.ProjectItems.AddFromFile(file.FullName);
+			ProjectItem item = project.ProjectItems.AddFromTemplate(file.FullName, itemType);
 			item.SetItemType(itemType);
 			return item;
 		}


### PR DESCRIPTION
Making this change will now run any `.editorconfig` rules in the project and thus things like honoring file-scoped namespaces.  Unknown other side-affects on other scenarios, but this works for .cs :-)

With this change and existence of `.editorconfig` the rules will apply.  This loses the template caret position behavior however, but mimics existing behavior of item templates (add class) where caret position is at 0.  It maintains the template behavior if not going through the formatter though.