### PR TITLE
Add support for VS2022

### DIFF
--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,17 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="d48e8f25-661b-4970-8b66-03f051ba5fc3" Version="4.1" Language="en-US" Publisher="Mads Kristensen" />
+        <Identity Id="d48e8f25-661b-4970-8b66-03f051ba5fc3" Version="4.2" Language="en-US" Publisher="Mads Kristensen" />
         <DisplayName>Add New File (64-bit)</DisplayName>
         <Description xml:space="preserve">The fastest and easiest way to add new files to any project - including files that start with a dot</Description>
         <MoreInfo>https://github.com/madskristensen/AddAnyFile</MoreInfo>
         <License>Resources\LICENSE</License>
+        <ReleaseNotes>Added support for Visual Studio 2022</ReleaseNotes>
         <Icon>Resources\logo.png</Icon>
         <PreviewImage>Resources\logo.png</PreviewImage>
         <Tags>file, add, template</Tags>
     </Metadata>
     <Installation InstalledByMsi="false">
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,22.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>


### PR DESCRIPTION
This pull requests simply modifies the VSIX manifest to allow installation within Visual Studio 2022. The extension works perfectly well in my testing, and 