### PR TITLE
Enable support for VS 2022 ARM64

### DIFF
--- a/src/AddAnyFile.csproj
+++ b/src/AddAnyFile.csproj
@@ -193,11 +193,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
-      <Version>17.0.0-previews-4-31709-430</Version>
+      <Version>17.10.40171</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.4207-preview4</Version>
+      <Version>17.11.414</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This change adds support for the `arm64` platform architecture by updating the tooling packages to the latest versions and adding a new entry for the `arm64` `ProductArchitecture`.

Note that there are some changes to the build warnings identified by analyzers after the package upgrades:

Before (master): 78 warnings
* 76 instances of [VSTHRD010](https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md)
* 1 instance of [RS0030](https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md)
* 1 instance of [VSTHRD200](https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md)

After: 91 warnings
* 90 instances of [VSTHRD010](https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md)
* 1 instance of [VSTHRD200](https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md)

Fixes https://github.com/madskristensen/AddAnyFile/issues/146.